### PR TITLE
Update other.d.ts

### DIFF
--- a/types/other.d.ts
+++ b/types/other.d.ts
@@ -1,1 +1,5 @@
-declare function print(message: string): void;
+/**
+ * Prints a message to the device log.
+ * @param message - The message to print.
+ */
+declare function print(...args: any[]): void;


### PR DESCRIPTION
print() can accept an arbitrary number of arguments, not just one string. It works similar to console.log().

For example:
```typescript
print("[home-assistant-ping] WiFi.SetConfig ERROR:", JSON.stringify(error));
```

The suggested change in types makes this possibe without TypeScript compilation errors.